### PR TITLE
Some regrex problem

### DIFF
--- a/lib/flake8.coffee
+++ b/lib/flake8.coffee
@@ -37,7 +37,7 @@ validate = ->
 
 
 flake = (filePath, callback) ->
-  line_expr = /:(\d+):(\d+): ([CEF]\d{3}) (.*)/
+  line_expr = /:(\d+):(\d+): ([CEFW]\d{3}) (.*)/
   errors = []
   currentIndex = -1
   skipLine = false


### PR DESCRIPTION
Hey, I think below case is also needed to handle.

```
krane_login_collector/daemon.py:20:40: W291 trailing whitespace
    def run(self, once=True, **kwargs):
                                       ^
```
